### PR TITLE
Fixed compile and linker errors with Visual Studio 2017 15.8.6

### DIFF
--- a/XamlHostingSample/Main.cpp
+++ b/XamlHostingSample/Main.cpp
@@ -1,13 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#include <windows.h>
-#include <windowsx.h>
-#include <stdlib.h>
-#include <string.h>
-#include <tchar.h>
 #include "pch.h"
-#include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>
 
 using namespace winrt;
 using namespace Windows::Foundation;

--- a/XamlHostingSample/XamlHostingSample.vcxproj
+++ b/XamlHostingSample/XamlHostingSample.vcxproj
@@ -104,10 +104,12 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -136,12 +138,14 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
+      <AdditionalDependencies>WindowsApp.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/XamlHostingSample/pch.h
+++ b/XamlHostingSample/pch.h
@@ -4,7 +4,12 @@
 #pragma once
 #ifndef PCH_H
 #define PCH_H
-#include <iostream>
+#include <unknwn.h>
+// WinBase.h
+// Windows::UI::Xaml::Media::Animation::IStoryboard::GetCurrentTime
+#ifdef GetCurrentTime
+#undef GetCurrentTime
+#endif
 #include <winrt/Windows.system.h>
 #include <winrt/Windows.UI.Core.h>
 #include <winrt/Windows.UI.Input.Inking.h>
@@ -18,4 +23,14 @@
 #include <winrt/Windows.UI.Xaml.Media.h>
 #include <winrt/Windows.Media.Core.h>
 #include <winrt/Windows.Media.Playback.h>
+
+#include <windows.ui.xaml.hosting.desktopwindowxamlsource.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <tchar.h>
+
+#include <windows.h>
+#include <windowsx.h>
 #endif


### PR DESCRIPTION
Fixed compile and linker errors with Visual Studio 2017 15.8.6 (missing C++17 standard, missing include, and conflicting preprocessor definition)